### PR TITLE
Fix CUDA setup URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ codellama-13b:
 
 ```bash
 # Install CUDA 12.x
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/\
+cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt update
 sudo apt install cuda-toolkit-12-4


### PR DESCRIPTION
## Summary
- fix the CUDA install command so the wrapped URL can be copied

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_683f418701e8832faf90a994361b44fb