### PR TITLE
Add simple chat persistence

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,67 +6,76 @@ from flask_socketio import SocketIO
 
 from .config import Config
 from .services.logging import setup_logging
+from .services.database import Database
 
 socketio = SocketIO()
+db = Database()
 
 
 def create_app(config_override: dict | None = None) -> Flask:
     """Create and configure the Flask application.
-    
+
     Args:
         config_override: Optional configuration overrides.
-        
+
     Returns:
         Configured Flask application.
     """
     # Setup logging first
     setup_logging(Config.LOG_LEVEL, Config.LOG_FORMAT)
     logger = structlog.get_logger(__name__)
-    
+
     # Create Flask app
     app = Flask(__name__)
     app.config.from_object(Config)
-    
+
     if config_override:
         app.config.update(config_override)
-    
+
     # Configure Flask for streaming
-    app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
-    app.config['RESPONSE_TIMEOUT'] = 300  # 5 minutes for long generations
-    
+    app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
+    app.config["RESPONSE_TIMEOUT"] = 300  # 5 minutes for long generations
+
     # Validate configuration
     Config.validate()
-    
+
     # Initialize extensions
     socketio.init_app(app, cors_allowed_origins="*" if Config.PUBLIC_MODE else None)
-    
+
+    # Initialize database
+    db.init_schema()
+    app.db = db
+
     # Register blueprints
     from .routes import api, chat, admin
+
     app.register_blueprint(api.bp)
     app.register_blueprint(chat.bp)
     app.register_blueprint(admin.bp)
-    
+
     # Initialize model registry
     from .services.model_registry import ModelRegistry
+
     app.model_registry = ModelRegistry()
-    
+
     # Load models on startup
     with app.app_context():
         try:
             app.model_registry.load_models()
         except Exception as e:
             logger.error("Failed to load models", error=str(e))
-    
+
     # Start background tasks
     if Config.GPU_MONITOR_INTERVAL > 0:
         from .services.gpu_monitor import start_gpu_monitoring
+
         start_gpu_monitoring(socketio)
-    
+
     logger.info(
         "LLM Cockpit initialized",
         host=Config.HOST,
         port=Config.PORT,
-        public_mode=Config.PUBLIC_MODE
+        public_mode=Config.PUBLIC_MODE,
     )
-    
-    return app 
+
+    return app

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -20,7 +20,9 @@ bp = Blueprint("chat", __name__, url_prefix="/")
 @bp.route("/favicon.ico")
 def favicon():
     """Serve favicon."""
-    return send_from_directory('static', 'favicon.ico', mimetype='image/vnd.microsoft.icon')
+    return send_from_directory(
+        "static", "favicon.ico", mimetype="image/vnd.microsoft.icon"
+    )
 
 
 @bp.route("/")
@@ -35,9 +37,9 @@ def index():
 def list_chats():
     """Get chat list for sidebar."""
 
-    # Return empty list since we don't have a database yet
-    # In a real implementation, this would query the database
-    chats: list[dict[str, Any]] = []
+    folder = request.args.get("folder")
+    search = request.args.get("q")
+    chats = current_app.db.list_chats(folder=folder, search=search)
 
     return render_template("components/chat_list.html", chats=chats)
 
@@ -45,9 +47,7 @@ def list_chats():
 @bp.route("/chat/folders")
 def list_folders():
     """Get folder list for sidebar."""
-    # Return empty list since we don't have a database yet
-    # In a real implementation, this would query the database
-    folders: list[dict[str, Any]] = []
+    folders = current_app.db.list_folders()
 
     return render_template("components/folder_list.html", folders=folders)
 
@@ -56,8 +56,8 @@ def list_folders():
 def search_chats():
     """Search chats."""
 
-    # Return empty results since we don't have a database yet
-    chats: list[dict[str, Any]] = []
+    query = request.args.get("q", "").strip()
+    chats = current_app.db.list_chats(search=query)
 
     return render_template("components/chat_list.html", chats=chats)
 
@@ -65,12 +65,11 @@ def search_chats():
 @bp.route("/chat/create", methods=["POST"])
 def create_chat():
     """Create a new chat."""
-    # For now, just reload the page to start a new chat
-    return jsonify({
-        "success": True,
-        "chat_id": None,
-        "redirect": "/"
-    })
+    title = request.form.get("title", "New Chat")
+    folder = request.form.get("folder") or None
+    chat_id = current_app.db.create_chat(title=title, folder=folder)
+
+    return jsonify({"success": True, "chat_id": chat_id})
 
 
 @bp.route("/chat/folder/create", methods=["POST"])
@@ -83,23 +82,51 @@ def create_folder():
     if not name:
         return jsonify({"error": "Folder name is required"}), 400
 
-    # For now, just return the folder (it won't persist)
+    current_app.db.create_folder(name)
     folder = {"name": name, "count": 0}
     return render_template("components/folder_item.html", folder=folder)
+
+
+@bp.route("/chat/<int:chat_id>/delete", methods=["POST"])
+def delete_chat(chat_id: int):
+    """Delete a chat."""
+    current_app.db.delete_chat(chat_id)
+    return jsonify({"success": True})
+
+
+@bp.route("/chat/<int:chat_id>/rename", methods=["POST"])
+def rename_chat(chat_id: int):
+    """Rename a chat."""
+    title = request.form.get("title", "New Chat").strip()
+    if not title:
+        return jsonify({"error": "Title required"}), 400
+    current_app.db.rename_chat(chat_id, title)
+    return jsonify({"success": True})
 
 
 @bp.route("/api/chat/<int:chat_id>")
 def get_chat(chat_id):
     """Get chat details."""
-    # Return empty chat since we don't have persistence yet
-    chat = {
-        "id": chat_id,
-        "title": "New Chat",
-        "messages": [],
-        "rag_files": []
-    }
+    try:
+        chat = current_app.db.get_chat(chat_id)
+        return jsonify(chat)
+    except KeyError:
+        return jsonify({"error": "Chat not found"}), 404
 
-    return jsonify(chat)
+
+@bp.route("/api/chat/<int:chat_id>/messages", methods=["POST"])
+def add_message(chat_id: int):
+    """Append a message to a chat."""
+    data = request.get_json() or {}
+    role = data.get("role")
+    content = data.get("content", "")
+    if role not in {"user", "assistant"} or not content:
+        return jsonify({"error": "Invalid payload"}), 400
+    try:
+        current_app.db.add_message(chat_id, role, content)
+    except KeyError:
+        return jsonify({"error": "Chat not found"}), 404
+    return jsonify({"success": True})
 
 
 @bp.route("/api/models")
@@ -112,15 +139,17 @@ def get_models():
         # Convert to the format expected by the frontend
         models = []
         for model_id, info in models_info.items():
-            models.append({
-                "name": model_id,
-                "display_name": info.get("display_name", model_id),
-                "type": info.get("engine", "unknown"),
-                "size": info.get("size", "unknown"),
-                "context_length": info.get("context_length", 0),
-                "loaded": info.get("loaded", False),
-                "active": info.get("active", False)
-            })
+            models.append(
+                {
+                    "name": model_id,
+                    "display_name": info.get("display_name", model_id),
+                    "type": info.get("engine", "unknown"),
+                    "size": info.get("size", "unknown"),
+                    "context_length": info.get("context_length", 0),
+                    "loaded": info.get("loaded", False),
+                    "active": info.get("active", False),
+                }
+            )
 
         return jsonify(models)
 
@@ -137,25 +166,32 @@ def get_model_info(model_name):
         model = model_registry.get_model(model_name)
         info = model.get_model_info()
 
-        return jsonify({
-            "name": model_name,
-            "type": info.get("engine", "unknown"),
-            "size": info.get("size", "unknown"),
-            "context_length": info.get("context_length", 0),
-            "loaded": model.is_loaded if hasattr(model, 'is_loaded') else False,
-            "memory_usage": info.get("memory_usage", "unknown")
-        })
+        return jsonify(
+            {
+                "name": model_name,
+                "type": info.get("engine", "unknown"),
+                "size": info.get("size", "unknown"),
+                "context_length": info.get("context_length", 0),
+                "loaded": model.is_loaded if hasattr(model, "is_loaded") else False,
+                "memory_usage": info.get("memory_usage", "unknown"),
+            }
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to get model info for {model_name}: {e}")
-        return jsonify({
-            "name": model_name,
-            "type": "unknown",
-            "size": "unknown",
-            "context_length": 0,
-            "loaded": False,
-            "memory_usage": "unknown"
-        }), 404
+        return (
+            jsonify(
+                {
+                    "name": model_name,
+                    "type": "unknown",
+                    "size": "unknown",
+                    "context_length": 0,
+                    "loaded": False,
+                    "memory_usage": "unknown",
+                }
+            ),
+            404,
+        )
 
 
 @bp.route("/api/models/<model_name>/load", methods=["POST"])
@@ -166,18 +202,17 @@ def load_model(model_name):
         model_registry.load_model(model_name)
 
         # Emit socket event to notify frontend of successful load
-        socketio = current_app.extensions.get('socketio')
+        socketio = current_app.extensions.get("socketio")
         if socketio:
-            socketio.emit('model_loaded', {
-                'model_id': model_name,
-                'status': 'loaded'
-            })
+            socketio.emit("model_loaded", {"model_id": model_name, "status": "loaded"})
 
-        return jsonify({
-            "success": True,
-            "message": f"Model {model_name} loaded successfully",
-            "loaded": True
-        })
+        return jsonify(
+            {
+                "success": True,
+                "message": f"Model {model_name} loaded successfully",
+                "loaded": True,
+            }
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to load model {model_name}: {e}")
@@ -192,18 +227,19 @@ def unload_model(model_name):
         model_registry.unload_model(model_name)
 
         # Emit socket event to notify frontend of successful unload
-        socketio = current_app.extensions.get('socketio')
+        socketio = current_app.extensions.get("socketio")
         if socketio:
-            socketio.emit('model_unloaded', {
-                'model_id': model_name,
-                'status': 'unloaded'
-            })
+            socketio.emit(
+                "model_unloaded", {"model_id": model_name, "status": "unloaded"}
+            )
 
-        return jsonify({
-            "success": True,
-            "message": f"Model {model_name} unloaded successfully",
-            "loaded": False
-        })
+        return jsonify(
+            {
+                "success": True,
+                "message": f"Model {model_name} unloaded successfully",
+                "loaded": False,
+            }
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to unload model {model_name}: {e}")
@@ -218,18 +254,19 @@ def switch_model(model_name):
         model_registry.switch_model(model_name)
 
         # Emit socket event to notify frontend of model switch
-        socketio = current_app.extensions.get('socketio')
+        socketio = current_app.extensions.get("socketio")
         if socketio:
-            socketio.emit('model_switched', {
-                'model_id': model_name,
-                'status': 'active'
-            })
+            socketio.emit(
+                "model_switched", {"model_id": model_name, "status": "active"}
+            )
 
-        return jsonify({
-            "success": True,
-            "message": f"Switched to model {model_name}",
-            "active": True
-        })
+        return jsonify(
+            {
+                "success": True,
+                "message": f"Switched to model {model_name}",
+                "active": True,
+            }
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to switch to model {model_name}: {e}")
@@ -253,7 +290,7 @@ def search_huggingface_models():
             search=query,
             filter=["gguf", "pytorch"],  # Focus on models likely to work
             limit=10,
-            sort="downloads"
+            sort="downloads",
         )
 
         results = []
@@ -263,61 +300,89 @@ def search_huggingface_models():
                 files = list_repo_files(model.id, token=os.getenv("HF_TOKEN"))
 
                 # Find GGUF files and other model files
-                gguf_files = [f for f in files if f.endswith('.gguf')]
-                other_files = [f for f in files if f.endswith(('.safetensors', '.bin', '.pt'))]
+                gguf_files = [f for f in files if f.endswith(".gguf")]
+                other_files = [
+                    f for f in files if f.endswith((".safetensors", ".bin", ".pt"))
+                ]
 
                 if gguf_files or other_files:
                     # Extract quantization info from GGUF files
                     quantizations = []
                     for gguf_file in gguf_files:
                         # Extract quantization from filename (e.g., Q4_K_M, Q5_0, etc.)
-                        parts = gguf_file.lower().split('.')
+                        parts = gguf_file.lower().split(".")
                         for part in parts:
-                            if any(q in part for q in ['q4', 'q5', 'q6', 'q8', 'f16', 'f32']):
+                            if any(
+                                q in part
+                                for q in ["q4", "q5", "q6", "q8", "f16", "f32"]
+                            ):
                                 size_mb = "Unknown"
                                 try:
                                     # Try to get file size (this might fail for private repos)
-                                    file_info = api.get_paths_info(model.id, [gguf_file])
+                                    file_info = api.get_paths_info(
+                                        model.id, [gguf_file]
+                                    )
                                     if file_info and len(file_info) > 0:
-                                        size_bytes = file_info[0].size if hasattr(file_info[0], 'size') else None
+                                        size_bytes = (
+                                            file_info[0].size
+                                            if hasattr(file_info[0], "size")
+                                            else None
+                                        )
                                         if size_bytes:
-                                            size_mb = f"{size_bytes / (1024*1024):.0f}MB"
+                                            size_mb = (
+                                                f"{size_bytes / (1024*1024):.0f}MB"
+                                            )
                                 except Exception:
                                     pass
 
-                                quantizations.append({
-                                    "name": part.upper(),
-                                    "file": gguf_file,
-                                    "size": size_mb
-                                })
+                                quantizations.append(
+                                    {
+                                        "name": part.upper(),
+                                        "file": gguf_file,
+                                        "size": size_mb,
+                                    }
+                                )
                                 break
 
                     # If no GGUF files, check if it's convertible
                     if not quantizations and other_files:
-                        quantizations.append({
-                            "name": "Convert to GGUF",
-                            "file": "convert",
-                            "size": "Will convert"
-                        })
+                        quantizations.append(
+                            {
+                                "name": "Convert to GGUF",
+                                "file": "convert",
+                                "size": "Will convert",
+                            }
+                        )
 
                     if quantizations:
-                        results.append({
-                            "id": model.id,
-                            "name": model.id.split('/')[-1],
-                            "full_name": model.id,
-                            "downloads": getattr(model, 'downloads', 0),
-                            "description": getattr(model, 'card_data', {}).get('description', '') if hasattr(model, 'card_data') and model.card_data else '',
-                            "quantizations": quantizations[:5]  # Limit to top 5 quantizations
-                        })
+                        results.append(
+                            {
+                                "id": model.id,
+                                "name": model.id.split("/")[-1],
+                                "full_name": model.id,
+                                "downloads": getattr(model, "downloads", 0),
+                                "description": (
+                                    getattr(model, "card_data", {}).get(
+                                        "description", ""
+                                    )
+                                    if hasattr(model, "card_data") and model.card_data
+                                    else ""
+                                ),
+                                "quantizations": quantizations[
+                                    :5
+                                ],  # Limit to top 5 quantizations
+                            }
+                        )
 
             except Exception as e:
-                current_app.logger.warning(f"Failed to get files for model {model.id}: {e}")
+                current_app.logger.warning(
+                    f"Failed to get files for model {model.id}: {e}"
+                )
                 continue
 
-        return jsonify({
-            "success": True,
-            "models": results[:10]  # Limit to top 10 results
-        })
+        return jsonify(
+            {"success": True, "models": results[:10]}  # Limit to top 10 results
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to search HuggingFace: {e}")
@@ -352,7 +417,9 @@ def download_model():
 
                 from huggingface_hub import hf_hub_download
 
-                app.logger.info(f"Starting download of {model_name}, file: {specific_file}")
+                app.logger.info(
+                    f"Starting download of {model_name}, file: {specific_file}"
+                )
 
                 if specific_file and specific_file != "convert":
                     # Download specific file
@@ -361,7 +428,7 @@ def download_model():
                             repo_id=model_name,
                             filename=specific_file,
                             token=os.getenv("HF_TOKEN"),
-                            local_dir=f"./models/{model_name.replace('/', '_')}"
+                            local_dir=f"./models/{model_name.replace('/', '_')}",
                         )
                         model_path = Path(local_file)
                         app.logger.info(f"Downloaded specific file to: {model_path}")
@@ -375,21 +442,28 @@ def download_model():
                     sys.path.insert(0, str(project_root))
 
                     from download_model import download_model as dl_model
+
                     model_path = dl_model(model_name, quantization=quantization)
 
                 if model_path and model_path.exists():
-                    app.logger.info(f"Model {model_name} downloaded successfully to {model_path}")
+                    app.logger.info(
+                        f"Model {model_name} downloaded successfully to {model_path}"
+                    )
 
                     # Since we now have dynamic model discovery, just reload the registry
                     # No need to update config files manually
                     with app.app_context():
                         try:
                             app.model_registry.reload_models()
-                            app.logger.info("Model registry reloaded, new model should be available")
+                            app.logger.info(
+                                "Model registry reloaded, new model should be available"
+                            )
                         except Exception as e:
                             app.logger.error(f"Failed to reload model registry: {e}")
                 else:
-                    app.logger.error(f"Download completed but model file not found: {model_path}")
+                    app.logger.error(
+                        f"Download completed but model file not found: {model_path}"
+                    )
 
             except Exception as e:
                 app.logger.error(f"Download error for model {model_name}: {e}")
@@ -399,10 +473,12 @@ def download_model():
         thread.daemon = True
         thread.start()
 
-        return jsonify({
-            "success": True,
-            "message": f"Started downloading {model_name} ({specific_file if specific_file else 'auto-convert'}). The model will appear in the dropdown once download completes."
-        })
+        return jsonify(
+            {
+                "success": True,
+                "message": f"Started downloading {model_name} ({specific_file if specific_file else 'auto-convert'}). The model will appear in the dropdown once download completes.",
+            }
+        )
 
     except Exception as e:
         current_app.logger.error(f"Failed to start download: {e}")
@@ -414,10 +490,7 @@ def refresh_models():
     """Manually refresh the model registry."""
     try:
         current_app.model_registry.reload_models()
-        return jsonify({
-            "success": True,
-            "message": "Models refreshed successfully"
-        })
+        return jsonify({"success": True, "message": "Models refreshed successfully"})
     except Exception as e:
         current_app.logger.error(f"Failed to refresh models: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
@@ -432,20 +505,20 @@ def get_available_models():
             "name": "microsoft/DialoGPT-medium",
             "display_name": "DialoGPT Medium",
             "size": "1.5GB",
-            "description": "Conversational model, good for chat"
+            "description": "Conversational model, good for chat",
         },
         {
             "name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
             "display_name": "TinyLlama 1.1B Chat",
             "size": "2.2GB",
-            "description": "Small but capable chat model"
+            "description": "Small but capable chat model",
         },
         {
             "name": "microsoft/DialoGPT-small",
             "display_name": "DialoGPT Small",
             "size": "500MB",
-            "description": "Lightweight conversational model"
-        }
+            "description": "Lightweight conversational model",
+        },
     ]
 
     return jsonify(available_models)

--- a/app/services/database.py
+++ b/app/services/database.py
@@ -1,0 +1,146 @@
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List
+from datetime import datetime
+
+from app.config import Config
+
+
+class Database:
+    """Simple SQLite wrapper for chat persistence."""
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = path or Config.DATABASE_URL.replace("sqlite:///", "")
+        self._conn: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        if not self._conn:
+            db_path = Path(self.path)
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            self._conn.row_factory = sqlite3.Row
+        return self._conn
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        return self.connect()
+
+    def init_schema(self) -> None:
+        sql = """
+        CREATE TABLE IF NOT EXISTS folders (
+            name TEXT PRIMARY KEY
+        );
+        CREATE TABLE IF NOT EXISTS chats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            folder TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(folder) REFERENCES folders(name) ON DELETE SET NULL
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            FOREIGN KEY(chat_id) REFERENCES chats(id) ON DELETE CASCADE
+        );
+        """
+        self.conn.executescript(sql)
+        self.conn.commit()
+
+    # Folder operations
+    def create_folder(self, name: str) -> None:
+        """Create a folder if it doesn't already exist."""
+        self.conn.execute(
+            "INSERT OR IGNORE INTO folders(name) VALUES (?)",
+            (name,)
+        )
+        self.conn.commit()
+
+    def list_folders(self) -> List[Dict[str, Any]]:
+        """Return folders with chat counts."""
+        rows = self.conn.execute(
+            "SELECT f.name, COUNT(c.id) AS count "
+            "FROM folders f LEFT JOIN chats c ON c.folder = f.name "
+            "GROUP BY f.name ORDER BY f.name"
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    # Chat operations
+    def create_chat(self, title: str = "New Chat", folder: str | None = None) -> int:
+        now = datetime.utcnow().isoformat()
+        if folder:
+            self.create_folder(folder)
+        cur = self.conn.execute(
+            "INSERT INTO chats(title, folder, created_at, updated_at) VALUES (?,?,?,?)",
+            (title, folder, now, now),
+        )
+        self.conn.commit()
+        return int(cur.lastrowid)
+
+    def delete_chat(self, chat_id: int) -> None:
+        self.conn.execute("DELETE FROM chats WHERE id=?", (chat_id,))
+        self.conn.commit()
+
+    def rename_chat(self, chat_id: int, title: str) -> None:
+        self.conn.execute(
+            "UPDATE chats SET title=?, updated_at=? WHERE id=?",
+            (title, datetime.utcnow().isoformat(), chat_id),
+        )
+        self.conn.commit()
+
+    def list_chats(
+        self, folder: str | None = None, search: str | None = None
+    ) -> List[Dict[str, Any]]:
+        query = (
+            "SELECT c.id, c.title, c.folder, c.created_at, c.updated_at, "
+            "(SELECT COUNT(*) FROM messages m WHERE m.chat_id=c.id) AS message_count "
+            "FROM chats c"
+        )
+        conditions: list[str] = []
+        params: list[Any] = []
+        if folder:
+            conditions.append("c.folder = ?")
+            params.append(folder)
+        if search:
+            conditions.append(
+                "(c.title LIKE ? OR EXISTS(SELECT 1 FROM messages m WHERE m.chat_id=c.id AND m.content LIKE ?))"
+            )
+            params.extend([f"%{search}%", f"%{search}%"])
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+        query += " ORDER BY c.updated_at DESC"
+        rows = self.conn.execute(query, params).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_chat(self, chat_id: int) -> Dict[str, Any]:
+        chat = self.conn.execute(
+            "SELECT id, title, folder, created_at, updated_at FROM chats WHERE id=?",
+            (chat_id,),
+        ).fetchone()
+        if not chat:
+            raise KeyError(chat_id)
+        messages = self.conn.execute(
+            "SELECT role, content, timestamp FROM messages WHERE chat_id=? ORDER BY id",
+            (chat_id,),
+        ).fetchall()
+        return {
+            "id": chat["id"],
+            "title": chat["title"],
+            "folder": chat["folder"],
+            "created_at": chat["created_at"],
+            "updated_at": chat["updated_at"],
+            "messages": [dict(m) for m in messages],
+            "rag_files": [],
+        }
+
+    def add_message(self, chat_id: int, role: str, content: str) -> None:
+        now = datetime.utcnow().isoformat()
+        self.conn.execute(
+            "INSERT INTO messages(chat_id, role, content, timestamp) VALUES (?,?,?,?)",
+            (chat_id, role, content, now),
+        )
+        self.conn.execute("UPDATE chats SET updated_at=? WHERE id=?", (now, chat_id))
+        self.conn.commit()

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -267,6 +267,7 @@ function chatInterface() {
         ragEnabled: false,
         ragFiles: [],
         eventSource: null,
+        chatId: null,
         
         init() {
             // Load settings from localStorage
@@ -277,6 +278,7 @@ function chatInterface() {
             // Load current chat if specified
             const chatId = new URLSearchParams(window.location.search).get('id');
             if (chatId) {
+                this.chatId = chatId;
                 this.loadChat(chatId);
             }
             
@@ -292,7 +294,15 @@ function chatInterface() {
         
         async sendMessage() {
             if (!this.currentMessage.trim() || this.isStreaming || !this.currentModel) return;
-            
+
+            // Ensure chat exists
+            if (!this.chatId) {
+                const res = await fetch('/chat/create', { method: 'POST' });
+                const data = await res.json();
+                this.chatId = data.chat_id;
+                history.replaceState({}, '', `?id=${this.chatId}`);
+            }
+
             // Add user message
             const userMessage = {
                 role: 'user',
@@ -300,6 +310,11 @@ function chatInterface() {
                 timestamp: new Date()
             };
             this.messages.push(userMessage);
+            fetch(`/api/chat/${this.chatId}/messages`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ role: 'user', content: userMessage.content })
+            });
             
             // Clear input
             const messageText = this.currentMessage;
@@ -412,11 +427,17 @@ function chatInterface() {
                 };
                 
                 await processChunk();
-                
+
                 // If no content was generated, show an error
                 if (!this.messages[messageIndex].content) {
                     this.messages[messageIndex].content = "I apologize, but I couldn't generate a response. Please try again.";
                 }
+
+                fetch(`/api/chat/${this.chatId}/messages`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ role: 'assistant', content: this.messages[messageIndex].content })
+                });
                 
             } catch (error) {
                 console.error('Chat error:', error);
@@ -484,6 +505,7 @@ function chatInterface() {
             try {
                 const response = await fetch(`/api/chat/${chatId}`);
                 const data = await response.json();
+                this.chatId = data.id;
                 this.messages = data.messages;
                 this.chatTitle = data.title;
                 this.ragFiles = data.rag_files || [];

--- a/app/templates/components/chat_list.html
+++ b/app/templates/components/chat_list.html
@@ -56,15 +56,22 @@
 function renameChat(chatId) {
     const newName = prompt('Enter new chat name:');
     if (newName) {
-        // TODO: Implement chat rename
-        console.log('Rename chat', chatId, 'to', newName);
+        fetch(`/chat/${chatId}/rename`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: `title=${encodeURIComponent(newName)}`
+        }).then(() => {
+            htmx.ajax('GET', '/chat/list', { target: '#chat-list', swap: 'innerHTML' });
+        });
     }
 }
 
 function deleteChat(chatId) {
     if (confirm('Are you sure you want to delete this chat?')) {
-        // TODO: Implement chat deletion
-        console.log('Delete chat', chatId);
+        fetch(`/chat/${chatId}/delete`, { method: 'POST' })
+            .then(() => {
+                htmx.ajax('GET', '/chat/list', { target: '#chat-list', swap: 'innerHTML' });
+            });
     }
 }
 </script> 

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -324,11 +324,13 @@ function setActiveFolder(element) {
 }
 
 function newChat() {
-    // Create new chat
-    htmx.ajax('POST', '/chat/create', {
-        target: '#main-content',
-        swap: 'innerHTML'
-    });
+    fetch('/chat/create', { method: 'POST' })
+        .then(response => response.json())
+        .then(data => {
+            if (data.chat_id) {
+                window.location.search = `?id=${data.chat_id}`;
+            }
+        });
 }
 
 function setCurrentModel(modelName) {


### PR DESCRIPTION
## Summary
- implement SQLite-based persistence
- create chat CRUD routes
- save messages when chatting
- enable chat list management on frontend
- persist folder names in database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5862e78c832fb6f2f3d7c8a273e5